### PR TITLE
Fixed collision and piece's movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,6 @@
-ClearAll;
+# Tetris Game in Mathematica #
+## Overview ##
+This code has been created during WLAS18. More information can be found [here](https://github.com/AlbanSdl/Mathematica-Chess)
 
-(* Initialisation *)
-
-boardinit = Table[0, 20, 10]; (* board empty *)
-board = boardinit; (* board in the game *)
-
-(*Creating pieces*)
-
-yellowp = ReplaceAll[1 -> Yellow][{{1, 1}, {1, 1}} ];
-redp = ReplaceAll[1 -> Red][{{1, 1, 0}, {0, 1, 1}}];
-greenp = ReplaceAll[1 ->  Green][{{1, 0}, {1, 1}, {0, 1}}];
-cyanp = ReplaceAll[1 -> Cyan][{{1}, {1}, {1}, {1}}];
-bluep = ReplaceAll[1 -> Blue][{{1, 1}, {1, 0}, {1, 0}}];
-orangep = ReplaceAll[1 -> Orange][{{1, 0}, {1, 0}, {1, 1}}];
-purplep = ReplaceAll[1 -> Purple][{{1, 0}, {1, 1}, {1, 0}}];
-lpiece = {{yellowp, Dimensions[yellowp]}, {redp, 
-    Dimensions[redp]}, {greenp, Dimensions[greenp]}, {cyanp, 
-    Dimensions[cyanp]}, {bluep, Dimensions[bluep]}, {orangep, 
-    Dimensions[orangep]}, {purplep, Dimensions[purplep]}};
-
-
-(* Functions *)
-
-newboard[board_, t_, 
-  p_] := {nboard = board; pie = p[[1]]; dim = p[[2]]; 
-   nboard[[t ;; t + dim[[1]] - 1, r ;; r + dim[[2]] - 1]] = pie; 
-   nboard}[[1]]
-
-collision[piece_, a_] := 
- a <= 20 && board[[a + piece[[2, 1]], r]] === 0 && 
-  board[[a + piece[[2, 1]], r + 1]] === 0
-
-R[x_] := Rotate[x, angle](*This function does not actually work*)
-
-
-(* Representations *)
-
-board = boardinit;
-r = 5; (*Placing the piece in the middle of the board at the \
-beginning*)
-angle = 0; 
-
-
-DynamicModule[{a = 0, piece = RandomChoice[lpiece, 1][[1]]},
- EventHandler[Dynamic[Row[{
-     MatrixPlot[board, ImageSize -> 200],
-     If[a == 20 - piece[[2, 1]] + 1,
-       {board = newboard[boardinit, a, piece], boardinit = board, 
-        a = 1, r = 5},
-       If[collision[piece, a],
-        If[
-         a == 0, {board = newboard[boardinit, 1, piece], 
-          a++}, {board = newboard[boardinit, a, piece], a++}],
-        {board = newboard[boardinit, a, piece], boardinit = board, 
-         a = 1, r = 5, piece = RandomChoice[lpiece, 1][[1]]}]];
-     }], TrackedSymbols :> {}, 
-   UpdateInterval -> 0.3],(*slowing down the DynamicModule*)
-  {"LeftArrowKeyDown" :> (r -= 1),(*Moving the piece left*)
-   "RightArrowKeyDown" :> (r += 1)(*Moving the piece right*)
-   }]]
+## License ##
+The license is being added by the repo's owner

--- a/tetris.wl
+++ b/tetris.wl
@@ -1,5 +1,13 @@
 (* ::Package:: *)
 
+(* WARNING, THIS IS EARLY ALPHA VERSION :
+	EVERYTHING IS NOT FINISHED AND FINE !
+	
+	Work in progress :
+	Prevent user from moving piece right or left into another
+*)
+
+
 (* Welcome to Mathematica Tetris Project !
 This package creates a simple playable Tetris game
 Just click "Run Package" and see magic appear ! *)
@@ -71,7 +79,7 @@ collision[piece_, a_]:= (
 	collisionCheckLocations[]:=(
 		rList = {};
 		Table[Table[
-			If[piece[[1, i, j]] == 0 && i =!= 1, AppendTo[rList, {i, j}]; If[MemberQ[rList, {i - 1, j}], rList = Complement[rList, {i - 1, j}]]];
+			If[piece[[1, i, j]] == 0 && i =!= 1 && !MemberQ[rList, {i - 1, j}], AppendTo[rList, {i, j}]];
 			If[a + i < 20 && i == Length[piece[[1]]] && piece[[1, i, j]] =!= 0, AppendTo[rList, {i + 1, j}]],
 		{j, 1, Length[piece[[1, i]]]}], {i, 1, Length[piece[[1]]]}];
 		Return[rList]

--- a/tetris.wl
+++ b/tetris.wl
@@ -1,0 +1,122 @@
+(* ::Package:: *)
+
+(* Welcome to Mathematica Tetris Project !
+This package creates a simple playable Tetris game
+Just click "Run Package" and see magic appear ! *)
+
+(* This function is not really useful and will be removed in future versions *)
+ClearAll;
+
+(* Initialisation *)
+boardinit=Table[0, 20, 10]; (* board empty *)
+board=boardinit; (* board in the game *)
+
+(* All the possible pieces of the game *)
+yellowPiece={{1, 1},{1, 1}} /. 1 -> Yellow;
+redPiece={{1, 1, 0},{0, 1, 1}} /. 1 -> Red;
+greenPiece={{1, 0}, {1, 1}, {0, 1}} /. 1 -> Green;
+cyanPiece={{1},{1},{1},{1}} /. 1 -> Cyan;
+bluePiece={{1,1},{1,0},{1,0}} /. 1 -> Blue;
+orangePiece={{1,0},{1,0},{1,1}} /. 1 -> Orange;
+purplePiece={{1,0},{1,1},{1,0}} /. 1 -> Purple;
+
+(* Here is a list (2 dimens array) of all the pieces *)
+lpiece={
+	{yellowPiece, Dimensions[yellowPiece]},
+	{redPiece, Dimensions[redPiece]},
+	{greenPiece, Dimensions[greenPiece]},
+	{cyanPiece, Dimensions[cyanPiece]},
+	{bluePiece, Dimensions[bluePiece]},
+	{orangePiece, Dimensions[orangePiece]},
+	{purplePiece, Dimensions[purplePiece]}
+};
+
+
+(* Functions *)
+
+(* Creates a blank new board *)
+newboard[board_, t_, p_]:={
+	nboard = board;
+	nboard[[t;;t+p[[2]][[1]]-1,r;;r+p[[2]][[2]]-1]] = p[[1]];
+	nboard
+}[[1]]
+
+(* Checks if there is collision with other pieces or sides of the board *)
+collision[piece_, a_]:= (
+	If[a == 20, Return[True]];
+	If[r <= 0 || r >= Length[board[[1]]], Return[True]];
+	a <= 20 && board[[a + piece[[2,1]], r]] === 0 && board[[a + piece[[2,1]], r+1]] === 0
+)
+(* Rotates a piece *)
+rotatePiece[piece_] := Rotate[piece, angle]
+
+(* Checks if the current piece can move in the provided direction.
+The direction can be symbolised with every number, positive or negative *)
+moveCurrentPiece[piece_, direction_]:=(
+	If[r > 1 && Sign[direction] == -1, r--];
+	(* r is dicreased of 1 because the location is count two times in r and Length[piece[[...]]] *)
+	If[r - 1 + Length[piece[[1, 1]]] < Length[board[[1]]] && Sign[direction] == 1, r++]
+)
+
+
+(* Representations *)
+
+board=boardinit;
+r=5; (*Placing the piece in the middle of the board at the beginning*)
+angle=0; 
+
+
+DynamicModule[
+	{
+		a=0,
+		piece=RandomChoice[lpiece,1][[1]]
+	},
+	EventHandler[
+		Dynamic[
+			Row[
+				{
+					MatrixPlot[
+						board, 
+						ImageSize -> 200
+					],
+					If[a == 20 - piece[[2,1]] + 1,
+						{
+							board=newboard[boardinit,a,piece],
+							boardinit=board,
+							a=1,
+							r=5
+						},
+						If[collision[piece, a],
+							If[a==0,
+								{
+									board=newboard[boardinit, 1, piece],
+									a++
+								},
+								{
+									board=newboard[boardinit, a, piece],
+									a++
+								}
+							],
+							{
+								board=newboard[boardinit, a, piece],
+								boardinit=board,
+								a=1,
+								r=5,
+								piece=RandomChoice[lpiece, 1][[1]]
+							}
+						]
+					];
+				}
+			],
+			TrackedSymbols :> {},
+			UpdateInterval -> 0.3
+		],(*slowing down the DynamicModule*)
+		{
+			"LeftArrowKeyDown" :> (moveCurrentPiece[piece, -1]),(*Moving the piece left*)
+			"RightArrowKeyDown" :> (moveCurrentPiece[piece, 1])(*Moving the piece right*)
+		}
+	]
+]
+
+
+


### PR DESCRIPTION
What's new : pieces don't create empty locations in the board and collision works quite well.

What's remaining :
- prevent user from moving pieces on a side into another piece
- add piece's rotation
- add way to accelerate piece when well placed
- remove a line when filled
- add way to count points
- add game over detection